### PR TITLE
Add a FileField and MultipleDocumentSelectField and allow passing of kwargs to fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.pyc
+.pydevproject
+.project

--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,3 @@
+#Wed Oct 05 02:14:15 CEST 2011
+eclipse.preferences.version=1
+encoding/setup.py=utf-8

--- a/mongotools/forms/fields.py
+++ b/mongotools/forms/fields.py
@@ -282,3 +282,6 @@ class MongoFormFieldGenerator(object):
             
             defaults.update(kwargs)
             return forms.MultipleChoiceField()
+        
+    def generate_filefield(self, field_name, field, **kwargs):
+        return forms.FileField(**kwargs)

--- a/mongotools/forms/fields.py
+++ b/mongotools/forms/fields.py
@@ -118,7 +118,8 @@ class DocumentMultipleChoiceField(ReferenceField):
                 filter_ids.append(oid)
             except InvalidId:
                 raise forms.ValidationError(self.error_messages['invalid_pk_value'] % pk)
-        qs = self.queryset.filter(**{'%s__in' % key: filter_ids})
+        qs = self.queryset.clone()
+        qs = qs.filter(**{'%s__in' % key: filter_ids})
         pks = set([force_unicode(getattr(o, key)) for o in qs])
         for val in value:
             if force_unicode(val) not in pks:

--- a/mongotools/forms/fields.py
+++ b/mongotools/forms/fields.py
@@ -88,14 +88,14 @@ class ReferenceField(forms.ChoiceField):
 class MongoFormFieldGenerator(object):
     """This class generates Django form-fields for mongoengine-fields."""
     
-    def generate(self, field_name, field):
+    def generate(self, field_name, field, **kwargs):
         """Tries to lookup a matching formfield generator (lowercase 
         field-classname) and raises a NotImplementedError of no generator
         can be found.
         """
         if hasattr(self, 'generate_%s' % field.__class__.__name__.lower()):
             return getattr(self, 'generate_%s' % \
-                field.__class__.__name__.lower())(field_name, field)
+                field.__class__.__name__.lower())(field_name, field, **kwargs)
         else:
             for cls in field.__class__.__bases__:
                 if hasattr(self, 'generate_%s' % cls.__name__.lower()):
@@ -129,7 +129,7 @@ class MongoFormFieldGenerator(object):
         if field.help_text:
             return field.help_text.capitalize()
 
-    def generate_stringfield(self, field_name, field):
+    def generate_stringfield(self, field_name, field, **kwargs):
         form_class = MongoCharField
 
         defaults = {'label': self.get_field_label(field_name, field),
@@ -156,51 +156,64 @@ class MongoFormFieldGenerator(object):
 
             if not field.required:
                 defaults['empty_value'] = None
-
+                
+        defaults.update(kwargs)
         return form_class(**defaults)
 
-    def generate_emailfield(self, field_name, field):
-        return forms.EmailField(
-            required=field.required,
-            min_length=field.min_length,
-            max_length=field.max_length,
-            initial=field.default,
-            label=self.get_field_label(field_name, field),
-            help_text= self.get_field_help_text(field)
-        )
+    def generate_emailfield(self, field_name, field, **kwargs):
+        defaults = {
+            'required': field.required,
+            'min_length': field.min_length,
+            'max_length': field.max_length,
+            'initial': field.default,
+            'label': self.get_field_label(field_name, field),
+            'help_text': self.get_field_help_text(field)    
+        }
+        
+        defaults.update(kwargs)
+        return forms.EmailField(**defaults)
 
-    def generate_urlfield(self, field_name, field):
-        return forms.URLField(
-            required=field.required,
-            min_length=field.min_length,
-            max_length=field.max_length,
-            initial=field.default,
-            label=self.get_field_label(field_name, field),
-            help_text= self.get_field_help_text(field)
-        )
+    def generate_urlfield(self, field_name, field, **kwargs):
+        defaults = {
+            'required': field.required,
+            'min_length': field.min_length,
+            'max_length': field.max_length,
+            'initial': field.default,
+            'label': self.get_field_label(field_name, field),
+            'help_text':  self.get_field_help_text(field)
+        }
+        
+        defaults.update(kwargs)
+        return forms.URLField(**defaults)
 
-    def generate_intfield(self, field_name, field):
+    def generate_intfield(self, field_name, field, **kwargs):
         if field.choices:
-            return forms.TypedChoiceField(
-                coerce=self.integer_field,
-                empty_value=None,
-                required=field.required,
-                initial=field.default,
-                label = self.get_field_label(field_name, field),
-                choices=field.choices,
-                help_text= self.get_field_help_text(field)
-            )
+            defaults = {
+                'coerce': self.integer_field,
+                'empty_value': None,
+                'required': field.required,
+                'initial': field.default,
+                'label': self.get_field_label(field_name, field),
+                'choices': field.choices,
+                'help_text': self.get_field_help_text(field)        
+            }
+            
+            defaults.update(kwargs)
+            return forms.TypedChoiceField(**defaults)
         else:
-            return forms.IntegerField(
-                required=field.required,
-                min_value=field.min_value,
-                max_value=field.max_value,
-                initial=field.default,
-                label = self.get_field_label(field_name, field),
-                help_text= self.get_field_help_text(field)
-                )
+            defaults = {
+                'required': field.required,
+                'min_value': field.min_value,
+                'max_value': field.max_value,
+                'initial': field.default,
+                'label': self.get_field_label(field_name, field),
+                'help_text': self.get_field_help_text(field)      
+            }
+            
+            defaults.update(kwargs)
+            return forms.IntegerField(**defaults)
 
-    def generate_floatfield(self, field_name, field):
+    def generate_floatfield(self, field_name, field, **kwargs):
 
         form_class = forms.FloatField
 
@@ -211,9 +224,10 @@ class MongoFormFieldGenerator(object):
                     'max_value': field.max_value,
                     'help_text': self.get_field_help_text(field)}
 
+        defaults.update(kwargs)
         return form_class(**defaults)
 
-    def generate_decimalfield(self, field_name, field):
+    def generate_decimalfield(self, field_name, field, **kwargs):
         form_class = forms.DecimalField
         defaults = {'label': self.get_field_label(field_name, field),
                     'initial': field.default,
@@ -222,33 +236,49 @@ class MongoFormFieldGenerator(object):
                     'max_value': field.max_value,
                     'help_text': self.get_field_help_text(field)}
 
+        defaults.update(kwargs)
         return form_class(**defaults)
 
-    def generate_booleanfield(self, field_name, field):
-        return forms.BooleanField(
-            required=field.required,
-            initial=field.default,
-            label = self.get_field_label(field_name, field),
-            help_text = self.get_field_help_text(field)
-        )
+    def generate_booleanfield(self, field_name, field, **kwargs):
+        defaults = {
+            'required': field.required,
+            'initial': field.default,
+            'label': self.get_field_label(field_name, field),
+            'help_text': self.get_field_help_text(field)     
+        }
+        
+        defaults.update(kwargs)
+        return forms.BooleanField(**defaults)
 
-    def generate_datetimefield(self, field_name, field):
-        return forms.DateTimeField(
-            required=field.required,
-            initial=field.default,
-            label = self.get_field_label(field_name, field),
-        )
+    def generate_datetimefield(self, field_name, field, **kwargs):
+        defaults = {
+            'required': field.required,
+            'initial': field.default,
+            'label': self.get_field_label(field_name, field),
+        }
+        
+        defaults.update(kwargs)
+        return forms.DateTimeField(**defaults)
 
-    def generate_referencefield(self, field_name, field):
-        return ReferenceField(field.document_type.objects,
-                              label = self.get_field_label(field_name, field),
-                              help_text = self.get_field_help_text(field),
-                              required=field.required)
+    def generate_referencefield(self, field_name, field, **kwargs):
+        defaults = {
+            'label': self.get_field_label(field_name, field),
+            'help_text': self.get_field_help_text(field),
+            'required': field.required
+        }
+        
+        defaults.update(kwargs)
+        return ReferenceField(field.document_type.objects, **defaults)
 
-    def generate_listfield(self, field_name, field):
+    def generate_listfield(self, field_name, field, **kwargs):
         if field.field.choices:
-            return forms.MultipleChoiceField(choices=field.field.choices,
-                                             required=field.required,
-                                             label = self.get_field_label(field_name, field),
-                                             help_text = self.get_field_help_text(field),
-                                             widget=forms.CheckboxSelectMultiple)
+            defaults = {
+                'choices': field.field.choices,
+                'required': field.required,
+                'label': self.get_field_label(field_name, field),
+                'help_text': self.get_field_help_text(field),
+                'widget': forms.CheckboxSelectMultiple     
+            }
+            
+            defaults.update(kwargs)
+            return forms.MultipleChoiceField()


### PR DESCRIPTION
These commits add a FileField and a multiple select field that works with mongoengine Listfields which contain reference fields.

Additionally kwargs passed to generate are passed through to the field constructor.
