### PR TITLE
Fixed the exception on cleaning the ReferenceField

### DIFF
--- a/mongotools/forms/fields.py
+++ b/mongotools/forms/fields.py
@@ -90,7 +90,7 @@ class ReferenceField(forms.TypedChoiceField):
 
         try:
             if self.coerce != int:
-                oid = ObjectId(value)
+                oid = ObjectId(oid)
 
             oid = super(ReferenceField, self).clean(oid)
 


### PR DESCRIPTION
Fixed exception:

Stacktrace (most recent call last):

  File "django/core/handlers/base.py", line 111, in get_response
    response = callback(request, _callback_args, *_callback_kwargs)

  File "django/views/generic/base.py", line 48, in view
    return self.dispatch(request, _args, *_kwargs)

  File "django/views/generic/base.py", line 69, in dispatch
    return handler(request, _args, *_kwargs)

  File "constructor/apps/admin/views.py", line 25, in post
    next = super(ChangelogMixin, self).post(request, _args, *_kwargs)

  File "mongotools/views/**init**.py", line 255, in post
    return super(BaseUpdateView, self).post(request, _args, *_kwargs)

  File "django/views/generic/edit.py", line 137, in post
    if form.is_valid():

  File "django/forms/forms.py", line 124, in is_valid
    return self.is_bound and not bool(self.errors)

  File "django/forms/forms.py", line 115, in _get_errors
    self.full_clean()

  File "django/forms/forms.py", line 270, in full_clean
    self._clean_fields()

  File "django/forms/forms.py", line 287, in _clean_fields
    value = field.clean(value)

  File "mongotools/forms/utils.py", line 23, in inner_validate
    value = old_clean(value)

  File "mongotools/forms/fields.py", line 93, in clean
    oid = ObjectId(value)
